### PR TITLE
Fix Docker volume conflict by separating application and data files

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,34 @@ A local hostable version of the services that [PKSM](https://github.com/FlagBrew
 ## How to Use
 See the [Setup Guide](https://github.com/FlagBrew/local-gpss/wiki/Server-Setup-Guide)
 
+## Docker Usage
+
+### Quick Start
+```bash
+# Build the image
+docker build -t local-gpss .
+
+# Run with temporary storage (data lost when container is removed)
+docker run -p 8080:8080 local-gpss
+```
+
+### Persistent Storage
+⚠️ **By default, data is lost when the container is removed.** To keep your Pokémon database and configuration:
+
+```bash
+# Create data directory with proper permissions
+mkdir -p ~/local-gpss-data
+chmod 777 ~/local-gpss-data
+
+# Run with persistent storage
+docker run -p 8080:8080 \
+  -e GPSS_DATA_DIR=/data \
+  -v ~/local-gpss-data:/data \
+  local-gpss
+```
+
+The application will prompt for initial setup on first run.
+
 ## Updating Auto Legality
 This is a pain to do, and is one of the reasons why Auto Legality never really stayed up to date.
 

--- a/database/Database.cs
+++ b/database/Database.cs
@@ -13,7 +13,8 @@ public class Database
 
     private Database()
     {
-        _connection = new SqliteConnection("Data Source=gpss.db;foreign keys=true;");
+        string dbPath = Path.Combine(local_gpss.utils.Helpers.GetDataDirectory(), "gpss.db");
+        _connection = new SqliteConnection($"Data Source={dbPath};foreign keys=true;");
         _connection.Open();
 
         Migrate();

--- a/utils/Helpers.cs
+++ b/utils/Helpers.cs
@@ -15,6 +15,16 @@ public static class Helpers
 {
     public static Random rand;
 
+    public static string GetDataDirectory()
+    {
+        var dataDir = Environment.GetEnvironmentVariable("GPSS_DATA_DIR") ?? Directory.GetCurrentDirectory();
+        if (!Directory.Exists(dataDir))
+        {
+            Directory.CreateDirectory(dataDir);
+        }
+        return dataDir;
+    }
+
     public static Config? Init()
     {
         EncounterEvent.RefreshMGDB(string.Empty);
@@ -25,7 +35,8 @@ public static class Helpers
         // Load config 
         try
         {
-            string config = File.ReadAllText("./local-gpss.json");
+            string configPath = Path.Combine(GetDataDirectory(), "local-gpss.json");
+            string config = File.ReadAllText(configPath);
             return JsonSerializer.Deserialize<Config>(config);
         }
         catch (Exception e)
@@ -237,7 +248,8 @@ public static class Helpers
     public static Config FirstTime()
     {
         var config = new Config();
-        bool isFirstTime = !File.Exists("gpss.db");
+        string dbPath = Path.Combine(GetDataDirectory(), "gpss.db");
+        bool isFirstTime = !File.Exists(dbPath);
         if (isFirstTime)
         {
             Console.WriteLine(
@@ -276,7 +288,7 @@ public static class Helpers
                         using (var s = client.GetStreamAsync(
                                    "https://github.com/FlagBrew/local-gpss/releases/download/v1.0.0/gpss.db"))
                         {
-                            using (var fs = new FileStream("gpss.db", FileMode.OpenOrCreate))
+                            using (var fs = new FileStream(dbPath, FileMode.OpenOrCreate))
                             {
                                 s.Result.CopyTo(fs);
                             }
@@ -476,7 +488,8 @@ public static class Helpers
         try
         {
             string json = JsonSerializer.Serialize(config);
-            File.WriteAllText("./local-gpss.json", json);
+            string configPath = Path.Combine(GetDataDirectory(), "local-gpss.json");
+            File.WriteAllText(configPath, json);
         }
         catch (Exception e)
         {


### PR DESCRIPTION
  **Problem**: 
 - Docker bind mounts to `/app` failed because mounting a host directory replaced application binaries, breaking the container.

  **Solution:**
  - Add configurable data directory via `GPSS_DATA_DIR` environment variable
  - Move config (`local-gpss.json`) and database (`gpss.db`) to separate directory
  - Default behavior unchanged: files still go to current working directory when env var not set
  - Docker can now mount volumes to `/data` without affecting application files in /app

  **Functionality Changes:**
  - Non-Docker usage: No change - files created in current directory as before
  - Docker without volume: No change - ephemeral storage in container
  - Docker with volume: NEW - persistent storage by setting `GPSS_DATA_DIR=/data` and mounting host directory

  **Benefits:**
  - Enables Docker persistent storage without volume conflicts
  - Preserves original behavior for existing users
  - Clean separation of application vs user data