### PR TITLE
Add libraries for GpssConsole in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ COPY --from=dotnet-build /app/output/GpssConsole ./bin/GpssConsole
 COPY --from=go-build /app/local-gpss ./local-gpss
 
 RUN echo "MODE=docker" > .env
-RUN apk add --no-cache gcompat libgcc icu-libs
+RUN apk add --no-cache gcompat libstdc++ libgcc icu-libs
 
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 CMD ["/app/local-gpss"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ COPY --from=dotnet-build /app/output/GpssConsole ./bin/GpssConsole
 COPY --from=go-build /app/local-gpss ./local-gpss
 
 RUN echo "MODE=docker" > .env
+RUN apk add --no-cache gcompat libgcc icu-libs
 
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 CMD ["/app/local-gpss"]


### PR DESCRIPTION
The Dockerfile is currently missing a few libraries necessary to run `GpssConsole`, so while the container starts fine, the legality checker endpoints don't work.

### GpssConsole Dynamically linked libraries
- `ld-linux-aarch64.so.1`: provided by `gcompat` package
- `libstdc++.so.6`: provided by `libstdc++` package
- `libgcc_s.so.1`: provided by `libgcc` package

### GpssConsole Dynamically loaded libraries
Not sure exactly which object files are loaded, but the executable loads some parts of `icu-libs` at runtime, and crashes if it isn't found.