### PR TITLE
Fix CI .NET SDK version to match project target (net10.0)

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: "9.0.x"
+          dotnet-version: "10.0.x"
 
       - name: Setup Go
         uses: actions/setup-go@v6


### PR DESCRIPTION
Fixes #11.

`build-and-release.yml` was pinning `dotnet-version: "9.0.x"` while `GpssConsole.csproj` targets `net10.0`. Changed to `"10.0.x"`.