### PR TITLE
Fix linux-arm64 artifact shipping x64 Go binary

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -17,9 +17,11 @@ jobs:
           - os: ubuntu-latest
             arch: linux-x64
             output: linux64
+            goarch: amd64
           - os: ubuntu-latest
             arch: linux-arm64
             output: linux-arm64
+            goarch: arm64
           - os: macos-latest
             arch: osx-x64
             output: osx64
@@ -55,6 +57,9 @@ jobs:
 
       - name: Build Local GPSS Linux
         if: runner.os == 'Linux'
+        env:
+          GOARCH: ${{ matrix.goarch }}
+          CGO_ENABLED: 0
         shell: bash
         run: |
           go build \


### PR DESCRIPTION
## Summary
- Adds `goarch` field to both Linux matrix entries (`amd64` for linux-x64, `arm64` for linux-arm64)
- Passes `GOARCH: ${{ matrix.goarch }}` and `CGO_ENABLED: 0` as env vars on the Linux Go build step
- `CGO_ENABLED: 0` is required for cross-compilation on the x64 runner; consistent with existing static build flags (`-tags=netgo,osusergo,static_build`, `-ldflags '-d -s -w -extldflags=-static'`)

Fixes #12

## Verification
All 4 matrix jobs passed on fork CI:
- ✅ [Build for ubuntu-latest (linux-arm64)](https://github.com/jackgopack4/local-gpss/actions/runs/25608665605/jobs/75174899712)
- ✅ [Build for ubuntu-latest (linux-x64)](https://github.com/jackgopack4/local-gpss/actions/runs/25608665605/jobs/75174899727)
- ✅ [Build for macos-latest (osx-x64)](https://github.com/jackgopack4/local-gpss/actions/runs/25608665605/jobs/75174899714)
- ✅ [Build for windows-latest (win-x64)](https://github.com/jackgopack4/local-gpss/actions/runs/25608665605/jobs/75174899721)

Binary arch confirmed with `file`:
- `linux-arm64/local-gpss` → `ELF 64-bit LSB executable, ARM aarch64`
- `linux64/local-gpss` → `ELF 64-bit LSB executable, x86-64`

## Test plan
- [x] All 4 matrix jobs pass in fork CI
- [x] `linux-arm64` artifact binary shows `ELF 64-bit LSB executable, ARM aarch64` via `file`
- [x] `linux64` artifact binary still shows `x86-64` via `file`